### PR TITLE
Add license to gemspec

### DIFF
--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
     "rb-inotify.gemspec"
   ]
   s.homepage = "http://github.com/nex3/rb-inotify"
+  s.license = "MIT"
   s.require_paths = ["lib"]
   s.rubygems_version = "2.0.3"
   s.summary = "A Ruby wrapper for Linux's inotify, using FFI"


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.