### PR TITLE
Run GC on "close" to make sure file descriptor is freed

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -244,6 +244,8 @@ module INotify
     def close
       if Native.close(@fd) == 0
         @watchers.clear
+        # Run GC to make sure file descriptor is freed
+        GC.start
         return
       end
 


### PR DESCRIPTION
My process closes and recreates a `INotify::Notifier` instance from time to time. After some time this process usually fails with "Bad file descriptor" when trying to `select` on the notifier's `IO` object.

I believe I can reproduce the problem:
```ruby
require 'rb-inotify'

begin
  nr = 1
  while true
    nr = nr + 1
    STDOUT.write("Iteration #{nr}\r") if 0 === nr%100
    notifier = INotify::Notifier.new
    notifier.to_io
    notifier.stop
    notifier.close
    notifier = nil
  end

rescue => e
  STDOUT.write("\nFailed: #{e.message} - #{e.backtrace.last}\n")
end
```

This usually fails with "Bad file descriptor" at `to_io` after ~2800 iterations.


Running a garbage collector run when closing a notifier solves the problem for me. I assume the file descriptor resources are not fully freed otherwise for some reason.

I suggest to add this to the library, to spare other people headache - wdyt?