### PR TITLE
Avoid exception in case of closing a file watched by notifier, like t…

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -275,6 +275,7 @@ module INotify
         tries += 1
         retry
       end
+      return [] if data.nil?
 
       events = []
       cookies = {}
@@ -296,7 +297,7 @@ module INotify
       begin
         return to_io.readpartial(size) if self.class.supports_ruby_io?
       rescue Errno::EBADF
-        return []
+        return nil
       end
 
       tries = 0

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -275,6 +275,7 @@ module INotify
         tries += 1
         retry
       end
+      # this will end up safely leaving from process method
       return [] if data.nil?
 
       events = []
@@ -295,7 +296,10 @@ module INotify
     def readpartial(size)
       # Use Ruby's readpartial if possible, to avoid blocking other threads.
       begin
+        # this will trigger Errno::EBADF when the file is closed
+        # this cannot be avoided even after Notifier::close is called
         return to_io.readpartial(size) if self.class.supports_ruby_io?
+      # to go out of this program without exception
       rescue Errno::EBADF
         return nil
       end


### PR DESCRIPTION
…rapping SIGINT to close the file without exception.

To continue after watching file is stopped without exception.

```
trap :INT do
    notifier.close
    file.close
end
 
notifier.run

# continue after watching file is stopped
...

```

