### PR TITLE
Add support for platforms with libinotify

### DIFF
--- a/lib/rb-inotify/native.rb
+++ b/lib/rb-inotify/native.rb
@@ -9,6 +9,10 @@ module INotify
   module Native
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
+    begin
+      ffi_lib 'inotify'
+    rescue LoadError
+    end
 
     # The C struct describing an inotify event.
     #


### PR DESCRIPTION
There is a kqueue/kevent based implementation of the inotify API developed for NetBSD/OpenBSD/FreeBSD and Mac OS X, provided via a shared library "libinotify.so".

I've confirmed that the following script works on FreeBSD 11-CURRENT, which recently extended its kqueue API to support wider range of the features necessary for the inotify API emulation to complete.

`ruby -Ilib -rrb-inotify -e 'notifier = INotify::Notifier.new; notifier.watch("foo", :close_write) {puts "foo was written"}; notifier.run'`